### PR TITLE
Add a solution to problem 2966

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -121,22 +121,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Gradle.Upgrade Gradle wrapper.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;problem739&quot;,
-    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;D:/gaps-/Documents/GitHub/hj-leetcode-kotlin&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Facets&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.41494253&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;Errors&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Gradle.Upgrade Gradle wrapper.executor": "Run",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "git-widget-placeholder": "main",
+    "ignore.virus.scanning.warn.message": "true",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "D:/gaps-/Documents/GitHub/hj-leetcode-kotlin",
+    "project.structure.last.edited": "Facets",
+    "project.structure.proportion": "0.15",
+    "project.structure.side.proportion": "0.41494253",
+    "settings.editor.selected.configurable": "Errors"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="D:\gaps-\Documents\GitHub\hj-leetcode-kotlin\src\main\kotlin\com\hj\leetcode\kotlin\medium" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="0ee37dc2-2f8a-4209-9ce5-75f80a72f2c6" name="Changes" comment="Improve readability" />
+    <list default="true" id="0ee37dc2-2f8a-4209-9ce5-75f80a72f2c6" name="Changes" comment="Add a solution to problem 2966" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -127,7 +127,7 @@
     "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "main",
+    "git-widget-placeholder": "problem2966",
     "ignore.virus.scanning.warn.message": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "D:/gaps-/Documents/GitHub/hj-leetcode-kotlin",
@@ -501,7 +501,7 @@
       <option name="project" value="LOCAL" />
       <updated>1687238935015</updated>
     </task>
-    <option name="localTasksCounter" value="921" />
+    <option name="localTasksCounter" value="922" />
     <servers />
   </component>
   <component name="UnknownFeatures">
@@ -545,7 +545,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Add a solution to problem 2610" />
     <MESSAGE value="Add a solution to problem 2125" />
     <MESSAGE value="Add a solution to problem 2870" />
     <MESSAGE value="Add a solution to problem 300" />
@@ -570,7 +569,8 @@
     <MESSAGE value="Add a solution to problem 1074" />
     <MESSAGE value="Improve readability" />
     <MESSAGE value="Improve readability" />
-    <option name="LAST_COMMIT_MESSAGE" value="Improve readability" />
+    <MESSAGE value="Add a solution to problem 2966" />
+    <option name="LAST_COMMIT_MESSAGE" value="Add a solution to problem 2966" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ at [LeetCode](https://leetcode.com/hj-core/).
 | [2785. Sort Vowels in a String](https://leetcode.com/problems/sort-vowels-in-a-string/)                                                                               | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem2785/Solution.kt)                                                                               | 2023-11-13    |
 | [2849. Determine if a Cell Is Reachable at a Given Time](https://leetcode.com/problems/determine-if-a-cell-is-reachable-at-a-given-time/)                             | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem2849/Solution.kt)                                                                               | 2023-11-08    |
 | [2870. Minimum Number of Operations to Make Array Empty](https://leetcode.com/problems/minimum-number-of-operations-to-make-array-empty/)                             | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem2870/Solution.kt)                                                                               | 2024-01-04    |
+| [2966. Divide Array Into Arrays With Max Difference](https://leetcode.com/problems/divide-array-into-arrays-with-max-difference/)                                     | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem2966/Solution.kt)                                                                               | 2024-02-01    |
 
 ### Easy
 

--- a/src/main/kotlin/com/hj/leetcode/kotlin/problem2966/Solution.kt
+++ b/src/main/kotlin/com/hj/leetcode/kotlin/problem2966/Solution.kt
@@ -5,7 +5,7 @@ package com.hj.leetcode.kotlin.problem2966
  */
 class Solution {
     /* Complexity:
-     * Time O(NLogN) and Space O(NLogN) where N is the size of nums;
+     * Time O(NLogN) and Space O(N) where N is the size of nums;
      */
     fun divideArray(nums: IntArray, k: Int): Array<IntArray> {
         val sorted = nums.sorted()

--- a/src/main/kotlin/com/hj/leetcode/kotlin/problem2966/Solution.kt
+++ b/src/main/kotlin/com/hj/leetcode/kotlin/problem2966/Solution.kt
@@ -1,0 +1,21 @@
+package com.hj.leetcode.kotlin.problem2966
+
+/**
+ * LeetCode page: [2966. Divide Array Into Arrays With Max Difference](https://leetcode.com/problems/divide-array-into-arrays-with-max-difference/);
+ */
+class Solution {
+    /* Complexity:
+     * Time O(NLogN) and Space O(NLogN) where N is the size of nums;
+     */
+    fun divideArray(nums: IntArray, k: Int): Array<IntArray> {
+        val sorted = nums.sorted()
+        val isImpossible = sorted.indices.step(3).any { sorted[it] + k < sorted[it + 2] }
+        if (isImpossible) {
+            return emptyArray()
+        }
+
+        return Array(sorted.size / 3) { i ->
+            intArrayOf(sorted[i * 3], sorted[i * 3 + 1], sorted[i * 3 + 2])
+        }
+    }
+}


### PR DESCRIPTION
The idea is simple, and the difficulty lies in proving its correctness. The greedy procedure involves sorting the nums and chunking them into size 3, then testing if each piece satisfies the required condition. To prove the correctness, we can separate it into two parts:
1. If the greedy procedure gives a valid partition, it is one of the valid results. 
This is easy to see.

2. If the greedy procedure fails to give a valid partition, there is no valid result.
Suppose the greedy procedure gives the partition [[a(1), a(2), a(3)], [a(4), a(5), a(6)], ..., [a(n-2), a(n-1), a(n)]], and let i be the smallest index such that [a(i), a(i+1), a(i+2)] cannot satisfy the condition, i.e., a(i) + k < a(i+2). Note that these numbers are in sorted order, which implies that a(1), a(2), ..., a(i), and possibly a(i+1) if a(i) + k >= a(i+1), have to form the partition themselves. However, they are missing at least one number to form the partition themselves, and this number must come from a(i+2) or later. Therefore, we conclude that we cannot obtain a valid result.

Combining parts 1 and 2, we have proved the correctness of the greedy procedure.