### PR TITLE
Add solutions to problem 3356

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ at [LeetCode](https://leetcode.com/hj-core/).
 | [3243. Shortest Distance After Road Addition Queries I](https://leetcode.com/problems/shortest-distance-after-road-addition-queries-i/)                                                         | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3243/Solution.kt)                                                                               | 2024-11-27    |
 | [3254. Find the Power of K-Size Subarrays I](https://leetcode.com/problems/find-the-power-of-k-size-subarrays-i/)                                                                               | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3254/Solution.kt)                                                                               | 2024-11-16    |
 | [3306. Count of Substrings Containing Every Vowel and K Consonants II](https://leetcode.com/problems/count-of-substrings-containing-every-vowel-and-k-consonants-ii/)                           | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3306/Solution.kt)                                                                               | 2025-03-10    |
+| [3356. Zero Array Transformation II](https://leetcode.com/problems/zero-array-transformation-ii/)                                                                                               | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3356/Solution.kt)                                                                               | 2025-03-13    |
 
 ### Easy
 

--- a/src/main/kotlin/com/hj/leetcode/kotlin/problem3356/Solution.kt
+++ b/src/main/kotlin/com/hj/leetcode/kotlin/problem3356/Solution.kt
@@ -1,0 +1,63 @@
+package com.hj.leetcode.kotlin.problem3356
+
+/**
+ * LeetCode page: [3356. Zero Array Transformation II](https://leetcode.com/problems/zero-array-transformation-ii/);
+ */
+class Solution {
+    // Complexity:
+    // Time O((N+M)LogN) and Space O(N)
+    // where N and M are the length of nums and queries, respectively.
+    fun minZeroArray(
+        nums: IntArray,
+        queries: Array<IntArray>,
+    ): Int {
+        val fenwickTree = FenwickTree(nums.size + 1)
+        var result = 0
+
+        // Find the shortest prefix of queries for each i such that nums[0..i] can be zeroed
+        for ((i, num) in nums.withIndex()) {
+            var remaining = num - fenwickTree.query(i)
+            while (0 < remaining && result < queries.size) {
+                val (left, right, decrement) = queries[result]
+                result++
+
+                if (i in left..right) {
+                    remaining -= decrement
+                }
+                fenwickTree.update(left, decrement)
+                fenwickTree.update(right + 1, -decrement)
+            }
+            if (remaining > 0) {
+                return -1
+            }
+        }
+        return result
+    }
+
+    private class FenwickTree(
+        size: Int,
+    ) {
+        private val tree = IntArray(size + 1) { 0 }
+
+        fun update(
+            index: Int,
+            increment: Int,
+        ) {
+            var i = index + 1
+            while (i < tree.size) {
+                tree[i] += increment
+                i += i and -i
+            }
+        }
+
+        fun query(index: Int): Int {
+            var i = index + 1
+            var sum = 0
+            while (i > 0) {
+                sum += tree[i]
+                i -= i and -i
+            }
+            return sum
+        }
+    }
+}

--- a/src/main/kotlin/com/hj/leetcode/kotlin/problem3356/Solution2.kt
+++ b/src/main/kotlin/com/hj/leetcode/kotlin/problem3356/Solution2.kt
@@ -1,0 +1,37 @@
+package com.hj.leetcode.kotlin.problem3356
+
+/**
+ * LeetCode page: [3356. Zero Array Transformation II](https://leetcode.com/problems/zero-array-transformation-ii/);
+ */
+class Solution2 {
+    // Complexity:
+    // Time O(N+M) and Space O(N)
+    // where N and M are the length of nums and queries, respectively.
+    fun minZeroArray(
+        nums: IntArray,
+        queries: Array<IntArray>,
+    ): Int {
+        val lineSweep = IntArray(nums.size + 1) { 0 }
+        var result = 0
+
+        // Find the shortest prefix of queries for each i such that nums[0..i] can be zeroed
+        for ((i, num) in nums.withIndex()) {
+            while (lineSweep[i] < num && result < queries.size) {
+                val (left, right, decrement) = queries[result]
+                result++
+
+                if (right < i) {
+                    continue
+                }
+                lineSweep[maxOf(left, i)] += decrement
+                lineSweep[right + 1] -= decrement
+            }
+
+            if (lineSweep[i] < num) {
+                return -1
+            }
+            lineSweep[i + 1] += lineSweep[i]
+        }
+        return result
+    }
+}


### PR DESCRIPTION
The main theme is to find the shortest prefix of `queries` for each `i` such that `nums[0..=i]` can be zeroed. Note that the length of the shortest prefix, i.e., `k`, is non-decreasing as `i` increases.

The first idea that comes to my mind is a two-pointer approach combined with a line sweep using a Fenwick tree. The two pointers are `i` and its corresponding `k`, and we use the line sweep with the Fenwick tree to check the decrement at index `i` and update the tree with the new query when necessary.

However, if you think carefully, when dealing with index `i`, what we need is the accumulated decrement at that index. New information regarding the previous indices is useless, and the update of information after the index can be delayed. This leads to a linear time line sweep with carry-over decrement knowledge.