### PR TITLE
Add a solution to problem 3394

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ at [LeetCode](https://leetcode.com/hj-core/).
 | [3254. Find the Power of K-Size Subarrays I](https://leetcode.com/problems/find-the-power-of-k-size-subarrays-i/)                                                                               | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3254/Solution.kt)                                                                               | 2024-11-16    |
 | [3306. Count of Substrings Containing Every Vowel and K Consonants II](https://leetcode.com/problems/count-of-substrings-containing-every-vowel-and-k-consonants-ii/)                           | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3306/Solution.kt)                                                                               | 2025-03-10    |
 | [3356. Zero Array Transformation II](https://leetcode.com/problems/zero-array-transformation-ii/)                                                                                               | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3356/Solution.kt)                                                                               | 2025-03-13    |
+| [3394. Check if Grid can be Cut into Sections](https://leetcode.com/problems/check-if-grid-can-be-cut-into-sections/)                                                                           | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3394/Solution.kt)                                                                               | 2025-03-25    |
 
 ### Easy
 

--- a/src/main/kotlin/com/hj/leetcode/kotlin/problem3394/Solution.kt
+++ b/src/main/kotlin/com/hj/leetcode/kotlin/problem3394/Solution.kt
@@ -1,0 +1,43 @@
+package com.hj.leetcode.kotlin.problem3394
+
+/**
+ * LeetCode page: [3394. Check if Grid can be Cut into Sections](https://leetcode.com/problems/check-if-grid-can-be-cut-into-sections/);
+ */
+class Solution {
+    // Complexity:
+    // Time O(MLogM) and Space O(M) where M is the length of rectangles.
+    fun checkValidCuts(
+        n: Int,
+        rectangles: Array<IntArray>,
+    ): Boolean {
+        val xIntervals = rectangles.mapTo(mutableListOf()) { intArrayOf(it[0], it[2]) }
+        xIntervals.sortBy { (start, end) -> start }
+        if (canCutToThree(xIntervals)) {
+            return true
+        }
+
+        val yIntervals = xIntervals
+        for ((i, rectangle) in rectangles.withIndex()) {
+            yIntervals[i][0] = rectangle[1]
+            yIntervals[i][1] = rectangle[3]
+        }
+        yIntervals.sortBy { (start, end) -> start }
+        return canCutToThree(yIntervals)
+    }
+
+    private fun canCutToThree(sortedIntervals: List<IntArray>): Boolean {
+        var cuts = 0
+        var currEnd = sortedIntervals[0][1]
+
+        for ((nextStart, nextEnd) in sortedIntervals) {
+            if (currEnd <= nextStart) {
+                cuts++
+                if (cuts == 2) {
+                    return true
+                }
+            }
+            currEnd = maxOf(currEnd, nextEnd)
+        }
+        return false
+    }
+}


### PR DESCRIPTION
The decision in one direction is not affected by the extent of rectangles in the other direction. We can check the two directions separately, and each rectangle reduces to an interval with respect to the direction.

Then, the problem transforms into determining whether we can cut the intervals into three non-empty groups. The idea is that a valid cut has the properties of not being earlier than the ends of all previous intervals and not being later than the starts of all subsequent intervals. We can sort the intervals by start and count the valid cuts with a linear scan.