### PR TITLE
Add a solution to problem 3373

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ at [LeetCode](https://leetcode.com/hj-core/).
 | [3203. Find Minimum Diameter After Merging Two Trees](https://leetcode.com/problems/find-minimum-diameter-after-merging-two-trees/)                                       | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3203/Solution.kt)                                                                               | 2024-12-24    |
 | [3272. Find the Count of Good Integers](https://leetcode.com/problems/find-the-count-of-good-integers/)                                                                   | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3272/Solution.kt)                                                                               | 2025-04-12    |
 | [3337. Total Characters in String After Transformations II](https://leetcode.com/problems/total-characters-in-string-after-transformations-ii/)                           | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3337/Solution.kt)                                                                               | 2025-05-14    |
+| [3373. Maximize the Number of Target Nodes After Connecting Trees II](https://leetcode.com/problems/maximize-the-number-of-target-nodes-after-connecting-trees-ii/)       | [Solution](src/main/kotlin/com/hj/leetcode/kotlin/problem3373/Solution.kt)                                                                               | 2025-05-29    |
 
 ### Medium
 

--- a/src/main/kotlin/com/hj/leetcode/kotlin/problem3373/Solution.kt
+++ b/src/main/kotlin/com/hj/leetcode/kotlin/problem3373/Solution.kt
@@ -1,0 +1,78 @@
+package com.hj.leetcode.kotlin.problem3373
+
+/**
+ * LeetCode page: [3373. Maximize the Number of Target Nodes After Connecting Trees II](https://leetcode.com/problems/maximize-the-number-of-target-nodes-after-connecting-trees-ii/);
+ */
+class Solution {
+    // Complexity:
+    // Time O(N+M) and Space O(N+M) where N and M are the length of edges1 and
+    // edges2 respectively.
+    fun maxTargetNodes(
+        edges1: Array<IntArray>,
+        edges2: Array<IntArray>,
+    ): IntArray {
+        val adjacencyList1 = computeAdjacencyList(edges1.size + 1, edges1)
+        var sizeGroup1A = 0
+        var sizeGroup1B = 0
+        val result = IntArray(adjacencyList1.size)
+
+        dfs(0, -1, 0, adjacencyList1) { node, depth ->
+            if (depth and 1 == 0) {
+                sizeGroup1A++
+                // result[node] = 0
+            } else {
+                sizeGroup1B++
+                result[node] = 1
+            }
+        }
+
+        val gain = computeMaxConnectionGain(edges2)
+        val answerGroupA = sizeGroup1A + gain
+        val answerGroupB = sizeGroup1B + gain
+        for (node in result.indices) {
+            result[node] = if (result[node] and 1 == 0) answerGroupA else answerGroupB
+        }
+        return result
+    }
+
+    private fun computeAdjacencyList(
+        n: Int,
+        edges: Array<IntArray>,
+    ): List<List<Int>> {
+        val result = List(n) { mutableListOf<Int>() }
+        for ((u, v) in edges) {
+            result[u].add(v)
+            result[v].add(u)
+        }
+        return result
+    }
+
+    private fun dfs(
+        node: Int,
+        parentNode: Int,
+        depth: Int,
+        adjacencyList: List<List<Int>>,
+        onEachNode: (node: Int, depth: Int) -> Unit,
+    ) {
+        onEachNode(node, depth)
+        for (child in adjacencyList[node]) {
+            if (child != parentNode) {
+                dfs(child, node, depth + 1, adjacencyList, onEachNode)
+            }
+        }
+    }
+
+    private fun computeMaxConnectionGain(edges2: Array<IntArray>): Int {
+        val adjacencyList2 = computeAdjacencyList(edges2.size + 1, edges2)
+        var sizeGroup2A = 0
+        var sizeGroup2B = 0
+        dfs(0, -1, 0, adjacencyList2) { node, depth ->
+            if (depth and 1 == 0) {
+                sizeGroup2A++
+            } else {
+                sizeGroup2B++
+            }
+        }
+        return maxOf(sizeGroup2A, sizeGroup2B)
+    }
+}


### PR DESCRIPTION
First, let's forget about tree 2. We choose an arbitrary node from tree 1; then, all nodes reachable by this node with an odd number of edges can reach each other via even edges, and all nodes reachable with an even number of edges can reach each other via even edges. So, without considering tree 2, you would expect only two distinct numbers in the resulting array.

Now, let's consider tree 2. We partition the nodes into two groups as we do for tree 1, and the maximum gain for a node in tree 1 is the larger size between the two groups. That is, we connect the querying node to a node in the smaller group so that all nodes in the larger group become reachable from the querying node via even edges.

To partition the nodes of a tree, we can perform a DFS and use the parity of the node depth as an indicator. Since each node has the same gain from tree 2, we would still expect only two distinct numbers in the resulting array.